### PR TITLE
In `git-fixup-head`, use HEAD instead of using `git-head-commit-id`

### DIFF
--- a/dot-files/zsh/.my-git-common
+++ b/dot-files/zsh/.my-git-common
@@ -25,7 +25,8 @@ alias git-head-commit-id='git rev-parse HEAD'
 
 alias git-fixup='git commit --fixup'
 
-alias git-fixup-head='git-fixup "$(git-head-commit-id)"'
+# alias git-fixup-head='git-fixup "$(git-head-commit-id)"'
+alias git-fixup-head='git-fixup HEAD'
 
 git-autosquash () {
   num_rex='^[0-9]+$'


### PR DESCRIPTION
In `git-fixup-head`, use HEAD instead of using `git-head-commit-id`.